### PR TITLE
minitest gem 4.7.5 to fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :development do
   gem "rdoc", "~> 3.12"
   gem "bundler", "~> 1.5"
   gem "jeweler", "~> 1.8"
-  gem "minitest"
+  gem "minitest", "~> 4.7.5"
 end


### PR DESCRIPTION
Using minitest version 4.7.5 seems to fix the issue with the tests: https://travis-ci.org/pchaigno/swot
It might be an old bug in minitest that "came back": https://bugs.ruby-lang.org/issues/8408